### PR TITLE
Bypass panic hook on caught panics during initialization

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@ use std::cell::UnsafeCell;
 use std::fmt::{self, Debug, Formatter};
 use std::marker::PhantomData;
 use std::mem::{self, ManuallyDrop};
-use std::panic::{panic_any, AssertUnwindSafe, RefUnwindSafe, UnwindSafe};
+use std::panic::{panic_any, resume_unwind, AssertUnwindSafe, RefUnwindSafe, UnwindSafe};
 use std::sync::Once;
 
 pub use either::Either;
@@ -915,7 +915,7 @@ impl<A, B> TwiceLock<A, B> {
         }))
         .map_err(|any| match any.downcast() {
             Ok(e) => *e,
-            Err(any) => panic_any(any),
+            Err(any) => resume_unwind(any),
         })
     }
 


### PR DESCRIPTION
Example:

```rust
use std::panic;
use twice_cell::TwiceLock;

struct Thing;

fn main() {
    panic::set_hook(Box::new(|panic_info| {
        if panic_info.payload().is::<Thing>() {
            println!("panic(Thing)");
        } else {
            println!("panic(non-Thing)");
        }
    }));

    match panic::catch_unwind(|| {
        let cell = TwiceLock::new(());
        let _: Result<&(), ()> = cell.get_or_try_init(|&()| {
            panic::panic_any(Thing);
        });
    }) {
        Ok(()) => unimplemented!(),
        Err(panic) => {
            if let Ok(&Thing) = panic.downcast().as_deref() {
                println!("success");
            } else {
                println!("wrong type");
            }
        }
    }
}
```

Before:

```console
panic(Thing)
panic(non-Thing)
wrong type
```

After:

```console
panic(Thing)
success
```

The "Before" behavior has 2 things wrong with it.

1. The user-defined panic hook gets called twice for only a single panic in the user's program.

2. The type that the user panicked with is corrupted, breaking downcasts in the user's program.